### PR TITLE
fix http issue with maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,6 @@
     </distributionManagement>
     <repositories>
         <repository>
-            <id>central</id>
-            <name>Central Repository</name>
-            <url>http://repo.maven.apache.org/maven2/ </url>
-        </repository>
-        <repository>
             <id>ohdsi</id>
             <name>repo.ohdsi.org</name>
             <url>http://repo.ohdsi.org:8085/nexus/content/repositories/releases</url>


### PR DESCRIPTION
remove http://repo.maven.apache.org/maven2 from pom
http is no longer supported by maven central. Default repo points to the correct https version 
https://stackoverflow.com/a/59764670/11676