### PR TITLE
Use the vocabulary schema for the concept table

### DIFF
--- a/java/main/resources/resources/cohortcharacterizations/sql/distributionRetrieving.sql
+++ b/java/main/resources/resources/cohortcharacterizations/sql/distributionRetrieving.sql
@@ -26,4 +26,4 @@ insert into @results_database_schema.cc_results (type, fa_type, covariate_id, co
     join (@featureRefs) fr on fr.covariate_id = f.covariate_id and fr.cohort_definition_id = f.cohort_definition_id
     join (@analysisRefs) ar
       on ar.analysis_id = fr.analysis_id and ar.cohort_definition_id = fr.cohort_definition_id
-    left join @cdm_database_schema.concept c on c.concept_id = fr.concept_id;
+    left join @vocabulary_database_schema.concept c on c.concept_id = fr.concept_id;

--- a/java/main/resources/resources/cohortcharacterizations/sql/prevalenceRetrieving.sql
+++ b/java/main/resources/resources/cohortcharacterizations/sql/prevalenceRetrieving.sql
@@ -21,4 +21,4 @@ insert into @results_database_schema.@results_table (type, fa_type, covariate_id
     join (@analysisRefs) ar
       on ar.analysis_id = fr.analysis_id and ar.cohort_definition_id = fr.cohort_definition_id
     {@temporal} ? {join #time_period t on t.time_id = f.time_id}
-    left join @cdm_database_schema.concept c on c.concept_id = fr.concept_id;
+    left join @vocabulary_database_schema.concept c on c.concept_id = fr.concept_id;


### PR DESCRIPTION
Closes #10 

This PR fixes the parameterization for 2 of the sql files in this repo to use the vocabulary schema in place of the cdm schema, which is where the concept table is located. 